### PR TITLE
Fix pymycobot install error

### DIFF
--- a/API/Python/setup.py
+++ b/API/Python/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=['pyserial'],
-    python_requires='2.7, >=3.5',
+    python_requires='>=2.7, >=3.5',
 )
 
 


### PR DESCRIPTION
Resolve the following error that is displayed while running `python setup.py install`.

```
error in pymycobot setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '2.7'
```