### PR TITLE
fix the wrong initialization of calibration_servo_no when the calibration is restarted

### DIFF
--- a/Arduino/MycobotBasic/examples/Calibration/Calibration.ino
+++ b/Arduino/MycobotBasic/examples/Calibration/Calibration.ino
@@ -115,7 +115,7 @@ void BtnCPressOnce()
   delay(50);
   
   M5.Lcd.print("Restart to calibrate");
-  calibrate_servo_no = 0;
+  calibrate_servo_no = 1;
   //关闭扭力输出
   myCobot.setFreeMove();
   delay(1000);


### PR DESCRIPTION
When the calibration is restarted with pushing the button C, the servo number starts with 0.  It should start with 1.