### PR TITLE
README: Put GitBook front-and-center; other minor cleanup

### DIFF
--- a/API/Python/README.md
+++ b/API/Python/README.md
@@ -1,1 +1,1 @@
-Please go to here.[https://github.com/elephantrobotics/pymycobot.git](https://github.com/elephantrobotics/pymycobot.git)
+Please see: <https://github.com/elephantrobotics/pymycobot.git>

--- a/Arduino/README.md
+++ b/Arduino/README.md
@@ -1,8 +1,37 @@
+# myCobot: Arduino
 
-# myCobot
-myCobot is the worlds smallest collaborative robot arm.   
-以上程序只适用于myCobot底座上的M5 Basic控制器进行使用  
-This is for M5 Basic Board to use only !
+Please review [root-level README](../) first!
+
+# M5 Stack Basic
+
+以上程序只适用于myCobot底座上的M5 Basic控制器进行使用
+This robot only deals with M5 Basic Board only!
+
+M5Stack Basic 的基本应用与烧录可以参考以下链接
+Please refer to the following link for the basic application and programming of
+M5Stack:
+
+- <https://docs.m5stack.com/#/zh_CN/core/basic> (Chinese)
+- <https://docs.m5stack.com/#/en/core/basic> (English)
+
+# Library & Example 
+
+To start, please see `MycobotBasic.h` and `MycobotBasic.cpp`
+
+## Update on 4th Feb
+
+Can only be used with AtomMain2.7 in myStudio1.0
+https://github.com/elephantrobotics/myStudio/releases
+
+```cc
+setEncoder(servo_number, encoder)  // can use to set gripper,servo_number should be 7, encoder should be 0-4096, but if you want use gripper, must get Gripper Value and set gripper init.
+
+getGripperValue() 	// return gripper encdoer value (from 0 to 4096)
+
+setPWMOutput(pin_number, frequency，ratio) // pin_number should be 13/22/23/33, frequency should be 100-100000, ratio should be 0 to 256（128 means 50% pwm）；
+```
+
+# FAQ
 
 如果您使用我们的库，并且需要运行历程,但是编译器提示mycobot_24px.h文件报错，那请您先修改语言配置  
 * windows  
@@ -10,21 +39,3 @@ This is for M5 Basic Board to use only !
 > 取消最后一句代码的注释,如图：
 
 ![font](font.png)
-
-# M5 Stack Basic
-M5Stack Basic 的基本应用与烧录可以参考以下链接
-https://docs.m5stack.com/#/zh_CN/core/basic
-
-# Library & Example 
-Should directly read MycobotBasic.h and MycobotBasic.cpp
-
-# Update on 4th Feb
-Can only be used with AtomMain2.7 in myStudio1.0
-https://github.com/elephantrobotics/myStudio/releases
-
-setEncoder(servo_number, encoder)  // can use to set gripper,servo_number should be 7, encoder should be 0-4096, but if you want use gripper, must get Gripper Value and set gripper init.
-
-getGripperValue() 	// return gripper encdoer value (from 0 to 4096)
-
-setPWMOutput(pin_number, frequency，ratio) // pin_number should be 13/22/23/33, frequency should be 100-100000, ratio should be 0 to 256（128 means 50% pwm）；
-

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 myCobot is the worlds smallest collaborative robot arm.
 以上程序只适用于 myCobot 底座上的 M5 Basic 控制器进行使用
-This is for M5 Basic Board to use only !
 
-# M5 Stack Basic
+Be sure to review the myCobot GitBook!
 
-M5Stack Basic 的基本应用与烧录可以参考以下链接
-https://docs.m5stack.com/#/zh_CN/core/basic
+- [myCobot (Chinese)](https://www.elephantrobotics.com/docs/myCobot)
+- [myCobot (English)](https://www.elephantrobotics.com/docs/myCobot-en)
 
-# Library & Example
+# Software, Libraries, and Examples
 
-如果您在使用案例，请先测试 SimpleTest.ino 文件验证通讯，该程序应烧录到底层 Basic 中
-请查看 Arduino 目录下的 API
-
-# Software
+- Arduino: [`./Arduino`](./Arduino)
+- Python:
+  [github: pymycobot](https://github.com/elephantrobotics/pymycobot.git) |
+  [pypi: pymycobot](https://pypi.org/project/pymycobot/)
+- ROS: [github: myCobotROS](https://github.com/elephantrobotics/myCobotROS.git)
+- Phone Controller: details for app in [`./Software/phone controller`](https://github.com/elephantrobotics/myCobot/tree/main/Software/phone%20controller)
 
 新版本的固件烧录器新增 ROS 与 Python 驱动固件，使用时请注意烧录终端与固件版本号
 
-**myCobot phone controller** : a phone app. [detial](https://github.com/elephantrobotics/myCobot/tree/main/Software/phone%20controller)
+The new version of the firmware burner (myStudio) adds ROS and Python driver
+firmware. Please review GitBook for which firmware versions to use!

--- a/ROS/README.md
+++ b/ROS/README.md
@@ -1,1 +1,1 @@
-python: [https://github.com/elephantrobotics/myCobotROS.git](https://github.com/elephantrobotics/myCobotROS.git)
+Please see: <https://github.com/elephantrobotics/myCobotROS.git>


### PR DESCRIPTION
I was confused for a bit b/c I jumped straight to GitHub; upon returning to website, I then saw GitBook cited at the top - that helps a ton!